### PR TITLE
fix: ssl_certificate_name may not be known in parent module.

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,6 @@
 locals {
-  elb_name    = var.elb_name != "" ? var.elb_name : var.name
-  sg_name     = var.elb_security_group_name != "" ? var.elb_security_group_name : "${var.name}-elb"
-  cert_name   = var.ssl_certificate_name != "" ? var.ssl_certificate_name : var.name
-  create_cert = var.ssl_certificate_arn == null && var.rtmps_enabled
+  elb_name  = var.elb_name != "" ? var.elb_name : var.name
+  sg_name   = var.elb_security_group_name != "" ? var.elb_security_group_name : "${var.name}-elb"
+  cert_name = var.ssl_certificate_name != "" ? var.ssl_certificate_name : var.name
 }
 

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aws_elb" "rtmp" {
       instance_protocol  = "tcp"
       lb_port            = 443
       lb_protocol        = "ssl"
-      ssl_certificate_id = local.create_cert ? aws_acm_certificate.cert.0.arn : var.ssl_certificate_arn
+      ssl_certificate_id = var.create_cert ? aws_acm_certificate.cert.0.arn : var.ssl_certificate_arn
     }
   }
 
@@ -183,7 +183,7 @@ resource "aws_route53_record" "rtmp" {
 
 # Certificate in AWS Certificate Manager
 resource "aws_acm_certificate" "cert" {
-  count             = local.create_cert ? 1 : 0
+  count             = var.create_cert ? 1 : 0
   domain_name       = var.ssl_certificate_domain_name
   validation_method = "DNS"
 
@@ -200,7 +200,7 @@ resource "aws_acm_certificate" "cert" {
 
 # DNS record to validate this certificate
 resource "aws_route53_record" "cert_validation" {
-  count   = local.create_cert ? 1 : 0
+  count   = var.create_cert ? 1 : 0
   name    = tolist(aws_acm_certificate.cert.0.domain_validation_options).0.resource_record_name
   type    = tolist(aws_acm_certificate.cert.0.domain_validation_options).0.resource_record_type
   zone_id = var.dns_hosted_zone_id
@@ -210,7 +210,7 @@ resource "aws_route53_record" "cert_validation" {
 
 # Certificate validation
 resource "aws_acm_certificate_validation" "cert" {
-  count                   = local.create_cert ? 1 : 0
+  count                   = var.create_cert ? 1 : 0
   certificate_arn         = aws_acm_certificate.cert.0.arn
   validation_record_fqdns = [aws_route53_record.cert_validation.0.fqdn]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -148,6 +148,12 @@ variable "rtmps_enabled" {
   default     = true
 }
 
+variable "create_cert" {
+  type        = bool
+  description = "Should the certificate be created by the module. If not, you must provide var.ssl_certificate_arn."
+  default     = true
+}
+
 variable "dns_hosted_zone_id" {
   type        = string
   description = "The ID of the hosted zone in Route53, under which the DNS record should be created."


### PR DESCRIPTION
The way local.create is computed implies the calling module has knowledge of this value to be able to compute the "count" parameter in resources. This is quite blocking, therefor moving this local to a variable. 