### PR TITLE
Remove S3 ACLs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -121,11 +121,6 @@ resource "aws_s3_bucket" "access_logs" {
   tags = var.tags
 }
 
-resource "aws_s3_bucket_acl" "access_logs" {
-  bucket = aws_s3_bucket.access_logs.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "access_logs" {
   count = var.access_logs_expiration != null ? 1 : 0
 


### PR DESCRIPTION
With the latest default policy change ACLs are disable & Block Public Access enable by default.
We have to remove ACLs on creation.
https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-faq.html