### PR TITLE
Switch module to Network Load Balancer

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,5 +1,5 @@
 locals {
-  elb_name  = var.elb_name != "" ? var.elb_name : var.name
-  sg_name   = var.elb_security_group_name != "" ? var.elb_security_group_name : "${var.name}-elb"
+  lb_name   = var.lb_name != "" ? var.lb_name : var.name
+  sg_name   = var.lb_security_group_name != "" ? var.lb_security_group_name : "${var.name}-elb"
   cert_name = var.ssl_certificate_name != "" ? var.ssl_certificate_name : var.name
 }

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "aws_lb_listener" "rtmps" {
   load_balancer_arn = aws_lb.rtmp.arn
   port              = "443"
   protocol          = "TLS"
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-0-2021-06" # Allow TLS 1.3, compatible down to 1.0
+  ssl_policy        = var.lb_ssl_policy
   certificate_arn   = var.create_cert ? aws_acm_certificate.cert[0].arn : var.ssl_certificate_arn
   default_action {
     type             = "forward"

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "dns_record" {
   description = "The DNS record for the RTMP endpoint"
   value       = aws_route53_record.rtmp.fqdn
 }
+
+output "lb_target_group_arn" {
+  value       = aws_lb_target_group.rtmp.arn
+  description = "The ARN of the target group of the RTMP load balancer."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,91 +19,98 @@ variable "subnet_ids" {
   default     = []
 }
 
-variable "elb_name" {
+variable "lb_name" {
   type        = string
   description = "Override the ELB name."
   default     = ""
 }
 
-variable "elb_cross_zone_load_balancing" {
+variable "lb_cross_zone_load_balancing" {
   type        = bool
   description = "Enable cross-zone load balancing."
   default     = false
 }
 
-variable "elb_idle_timeout" {
+variable "lb_idle_timeout" {
   type        = number
   description = "The time in seconds that the connection is allowed to be idle."
   default     = 60
 }
 
-variable "elb_connection_draining" {
+variable "lb_connection_termination" {
   type        = bool
-  description = "Boolean to enable connection draining."
-  default     = true
+  description = "Whether to terminate connections at the end of the deregistration timeout on Network Load Balancers."
+  default     = false
 }
 
-variable "elb_connection_draining_timeout" {
+variable "lb_deregistration_delay" {
   type        = number
-  description = "The time in seconds to allow for connections to drain."
+  description = "The time to wait for in-flight requests to complete while deregistering a target."
   default     = 300
 }
 
-variable "elb_health_check_healthy_threshold" {
+variable "lb_unhealthy_connection_termination" {
+  type        = bool
+  description = "Whether the load balancer terminates connections to unhealthy targets."
+  default     = true
+}
+
+variable "lb_health_check_healthy_threshold" {
   type        = number
   description = "The number of checks before the instance is declared healthy."
   default     = 6
 }
 
-variable "elb_health_check_unhealthy_threshold" {
+variable "lb_health_check_unhealthy_threshold" {
   type        = number
   description = "The number of checks before the instance is declared unhealthy."
   default     = 2
 }
 
-variable "elb_health_check_timeout" {
+variable "lb_health_check_timeout" {
   type        = number
   description = "The interval between checks."
   default     = 5
 }
 
-variable "elb_health_check_interval" {
+variable "lb_health_check_interval" {
   type        = number
   description = "The length of time before the check times out."
   default     = 10
 }
 
-variable "elb_security_group_name" {
+variable "lb_security_group_name" {
   type        = string
   description = "Override the ELB security group name."
   default     = ""
 }
 
-variable "elb_ingress_cidr_blocks_rtmp" {
+variable "lb_ingress_cidr_blocks_rtmp" {
   type        = list(string)
-  description = "CIDRs to allow for the rtmp ingress."
+  description = "CIDRs to allow for the RTMP ingress."
   default     = ["0.0.0.0/0"]
 }
 
-variable "elb_ingress_cidr_blocks_rtmps" {
+variable "lb_ingress_cidr_blocks_rtmps" {
   type        = list(string)
-  description = "CIDRs to allow for the rtmps ingress."
+  description = "CIDRs to allow for the RTMPS ingress."
   default     = ["0.0.0.0/0"]
 }
 
 variable "rtmp_backend_ingress_port" {
   type        = string
-  description = "The rtmp backend ingress port (envoy port for rtmp)."
+  description = "The RTMP backend ingress port (envoy port for rtmp)."
 }
 
 variable "rtmp_backend_security_group_id" {
   type        = string
-  description = "The rtmp backend security group id (used to allow ingress on rtmp_backend_ingress_port)."
+  description = "The RTMP backend security group id (used to allow ingress on rtmp_backend_ingress_port)."
 }
 
 variable "rtmp_backend_autoscaling_group_name" {
   type        = string
-  description = "The rtmp backend ASG name."
+  description = "The RTMP backend ASG name."
+  default     = ""
 }
 
 variable "access_logs_enabled" {
@@ -122,12 +129,6 @@ variable "access_logs_bucket_prefix" {
   type        = string
   description = "The access logs bucket prefix. Logs are stored in the root if not configured."
   default     = null
-}
-
-variable "access_logs_interval" {
-  type        = number
-  description = "The publishing interval in minutes."
-  default     = 60
 }
 
 variable "access_logs_expiration" {
@@ -179,7 +180,7 @@ variable "ssl_certificate_name" {
 
 variable "ssl_certificate_domain_name" {
   type        = string
-  description = "The complete domain name that will be written in the TLS certificate. Can include a wildcard. Required for rtmps."
+  description = "The complete domain name that will be written in the TLS certificate. Can include a wildcard. Required for RTMPS."
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -97,6 +97,12 @@ variable "lb_ingress_cidr_blocks_rtmps" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "lb_ssl_policy" {
+  type        = string
+  description = "Name of the SSL Policy for the listener."
+  default     = "ELBSecurityPolicy-TLS13-1-0-2021-06" # Allow TLS 1.3, compatible down to 1.0
+}
+
 variable "rtmp_backend_ingress_port" {
   type        = string
   description = "The RTMP backend ingress port (envoy port for rtmp)."

--- a/versions.tf
+++ b/versions.tf
@@ -20,8 +20,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = ">= 5.23.0"
     }
   }
-
 }


### PR DESCRIPTION
**Context**

To use nodes that are not in an [Auto Scaling groups](https://docs.aws.amazon.com/autoscaling/ec2/userguide/auto-scaling-groups.html) (e.g. when using Karpenter), we need to switch to an AWS NLB to be able to use [aws-load-balancer-controller TargetGroupBindings](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/targetgroupbinding/targetgroupbinding/), and to make rtmp_backend_autoscaling_group_name optional.

**Description**
* Replace Classic Load Balancer with a Network Load Balancer, which has the side effect of reducing costs
* Made rtmp_backend_autoscaling_group_name optional

This change is breaking and will need a manual removal of the Classic ELB from the state to let connections drain : 
```
terraform state rm \
    "module.rtmp.module.rtmp_loadbalancer[0].aws_elb.rtmp" \
    "module.rtmp.module.rtmp_loadbalancer[0].aws_autoscaling_attachment.rtmp" \
    "module.rtmp.module.rtmp_loadbalancer[0].aws_s3_bucket_policy.access_logs" \
    "module.rtmp.module.rtmp_loadbalancer[1].aws_elb.rtmp" \
    "module.rtmp.module.rtmp_loadbalancer[1].aws_autoscaling_attachment.rtmp" \
    "module.rtmp.module.rtmp_loadbalancer[1].aws_s3_bucket_policy.access_logs"
```